### PR TITLE
Standardize copyright headers.

### DIFF
--- a/.github/copyright.sh
+++ b/.github/copyright.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+
+# If there are new files with headers that can't match the conditions here,
+# then the files can be ignored by an additional glob argument via the -g flag.
+# For example:
+#   -g "!src/special_file.rs"
+#   -g "!src/special_directory"
+
+# Check all the standard Rust source files
+output=$(rg "^// Copyright (19|20)[\d]{2} (.+ and )?the Android Trace Authors( and .+)?$\n^// SPDX-License-Identifier: Apache-2\.0 OR MIT$\n\n" --files-without-match --multiline -g "*.rs" .)
+
+if [ -n "$output" ]; then
+	echo -e "The following files lack the correct copyright header:\n"
+	echo $output
+	echo -e "\n\nPlease add the following header:\n"
+	echo "// Copyright $(date +%Y) the Android Trace Authors"
+	echo "// SPDX-License-Identifier: Apache-2.0 OR MIT"
+	echo -e "\n... rest of the file ...\n"
+	exit 1
+fi
+
+echo "All files have correct copyright headers."
+exit 0

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -66,14 +66,13 @@ jobs:
       - name: cargo fmt
         run: cargo fmt --all --check
 
-      # TODO: Probably should have copyright headers 
-      # - name: install ripgrep
-      #   run: |
-      #     sudo apt update
-      #     sudo apt install ripgrep
+      - name: install ripgrep
+        run: |
+          sudo apt update
+          sudo apt install ripgrep
 
-      # - name: check copyright headers
-      #   run: bash .github/copyright.sh
+      - name: check copyright headers
+        run: bash .github/copyright.sh
 
   clippy-stable:
     name: cargo clippy

--- a/AUTHORS
+++ b/AUTHORS
@@ -4,4 +4,3 @@
 # especially since many employees of one corporation may be contributing.
 # To see the full list of contributors, see the revision history in
 # source control.
-Daniel McNab

--- a/AUTHORS
+++ b/AUTHORS
@@ -4,3 +4,4 @@
 # especially since many employees of one corporation may be contributing.
 # To see the full list of contributors, see the revision history in
 # source control.
+Google LLC

--- a/AUTHORS
+++ b/AUTHORS
@@ -1,0 +1,7 @@
+# This is the list of Android Trace's significant contributors.
+#
+# This does not necessarily list everyone who has contributed code,
+# especially since many employees of one corporation may be contributing.
+# To see the full list of contributors, see the revision history in
+# source control.
+Daniel McNab

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ resolver = "2"
 
 [workspace.package]
 version = "0.1.0"
-license = "MIT OR Apache-2.0"
+license = "Apache-2.0 OR MIT"
 # Keep in sync with RUST_MIN_VER in .github/workflows/ci.yml and with the relevant README.md files.
 # We use C string literals
 rust-version = "1.77"

--- a/android_trace/src/ffi.rs
+++ b/android_trace/src/ffi.rs
@@ -1,3 +1,6 @@
+// Copyright 2024 the Android Trace Authors
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+
 #[cfg(not(all(feature = "api_level_23", feature = "api_level_29")))]
 use core::{
     ffi::{c_void, CStr},

--- a/android_trace/src/lib.rs
+++ b/android_trace/src/lib.rs
@@ -1,3 +1,6 @@
+// Copyright 2024 the Android Trace Authors
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+
 #![doc = concat!(
 // TODO: Is this a new pattern?
 "[AndroidTrace]: crate::AndroidTrace

--- a/tracing_android_trace/src/async_layer.rs
+++ b/tracing_android_trace/src/async_layer.rs
@@ -1,3 +1,6 @@
+// Copyright 2024 the Android Trace Authors
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+
 use std::ffi::CString;
 
 use android_trace::AndroidTrace;

--- a/tracing_android_trace/src/lib.rs
+++ b/tracing_android_trace/src/lib.rs
@@ -1,3 +1,6 @@
+// Copyright 2024 the Android Trace Authors
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+
 #![doc = concat!(
 // TODO: Is this a new pattern?
 "[`tracing`]: tracing

--- a/tracing_android_trace/src/sync_layer.rs
+++ b/tracing_android_trace/src/sync_layer.rs
@@ -1,3 +1,6 @@
+// Copyright 2024 the Android Trace Authors
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+
 use thread_local::ThreadLocal;
 
 use std::{


### PR DESCRIPTION
This PR adds standard Linebender copyright headers to all the Rust source files. Plus activating the CI check and adding an `AUTHORS` file.