### PR TITLE
Prepare for 0.1.1

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,7 +4,7 @@ env:
   # come automatically. If the version specified here is no longer the latest stable version,
   # then please feel free to submit a PR that adjusts it along with the potential clippy fixes.
   # When updating this, also update RUST_DOCS_COMPILE_VER below to the same version
-  RUST_STABLE_VER: "1.77" # In quotes because otherwise (e.g.) 1.70 would be interpreted as 1.7
+  RUST_STABLE_VER: "1.79" # In quotes because otherwise (e.g.) 1.70 would be interpreted as 1.7
   # The version of rustc we use to test that doc examples compile.
   # This is required because we depend on the unstable `-Zdoctest-xcompile`.
   # See https://github.com/rust-lang/rust/issues/64245

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,45 @@
+<!-- Instructions
+
+This changelog follows the patterns described here: <https://keepachangelog.com/en/>.
+
+Subheadings to categorize changes are `added, changed, deprecated, removed, fixed, security`.
+
+-->
+
+# Changelog
+
+The latest published Vello release is [0.1.1](#011---2024-06-14) which was released on 2024-06-08.
+You can find its changes [documented below](#010---2024-04-03).
+
+## [Unreleased]
+
+### Added
+
+### Changed
+
+### Fixed
+
+## [0.1.1] - 2024-06-14
+
+### Added
+
+- License files in Cargo packages ([#12] by [@DJMcNab])
+
+### Changed
+
+- Badges to match Linebender standard ([#11] by [@DJMcNab])
+
+### Fixed
+
+## [0.1.0] - 2024-04-03
+
+- Initial release
+
+[@DJMcNab]: https://github.com/DJMcNab
+
+[#11]: https://github.com/linebender/android_trace/pull/11
+[#12]: https://github.com/linebender/android_trace/pull/12
+
+[Unreleased]: https://github.com/linebender/vello/compare/v0.1.1...HEAD
+[0.1.1]: https://github.com/linebender/vello/compare/v0.1.0...v0.1.1
+[0.1.0]: https://github.com/linebender/vello/releases/tag/v0.1.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,8 +8,8 @@ Subheadings to categorize changes are `added, changed, deprecated, removed, fixe
 
 # Changelog
 
-The latest published Vello release is [0.1.1](#011---2024-06-14) which was released on 2024-06-08.
-You can find its changes [documented below](#010---2024-04-03).
+The latest published Android Trace release is [0.1.1](#011---2024-06-14) which was released on 2024-06-08.
+You can find its changes [documented below](#011---2024-06-14).
 
 ## [Unreleased]
 
@@ -40,6 +40,6 @@ You can find its changes [documented below](#010---2024-04-03).
 [#11]: https://github.com/linebender/android_trace/pull/11
 [#12]: https://github.com/linebender/android_trace/pull/12
 
-[Unreleased]: https://github.com/linebender/vello/compare/v0.1.1...HEAD
-[0.1.1]: https://github.com/linebender/vello/compare/v0.1.0...v0.1.1
-[0.1.0]: https://github.com/linebender/vello/releases/tag/v0.1.0
+[Unreleased]: https://github.com/linebender/android_trace/compare/v0.1.1...HEAD
+[0.1.1]: https://github.com/linebender/android_trace/compare/v0.1.0...v0.1.1
+[0.1.0]: https://github.com/linebender/android_trace/releases/tag/v0.1.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ Subheadings to categorize changes are `added, changed, deprecated, removed, fixe
 
 # Changelog
 
-The latest published Android Trace release is [0.1.1](#011---2024-06-14) which was released on 2024-06-08.
+The latest published Android Trace release is [0.1.1](#011---2024-06-14) which was released on 2024-06-14.
 You can find its changes [documented below](#011---2024-06-14).
 
 ## [Unreleased]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ You can find its changes [documented below](#011---2024-06-14).
 ### Added
 
 - License files in Cargo packages ([#12] by [@DJMcNab])
+- This changelog ([#13] by [@DJMcNab])
 
 ### Changed
 
@@ -39,6 +40,7 @@ You can find its changes [documented below](#011---2024-06-14).
 
 [#11]: https://github.com/linebender/android_trace/pull/11
 [#12]: https://github.com/linebender/android_trace/pull/12
+[#13]: https://github.com/linebender/android_trace/pull/13
 
 [Unreleased]: https://github.com/linebender/android_trace/compare/v0.1.1...HEAD
 [0.1.1]: https://github.com/linebender/android_trace/compare/v0.1.0...v0.1.1

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,7 +4,7 @@ version = 3
 
 [[package]]
 name = "android_trace"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "libc",
  "static_assertions",
@@ -146,7 +146,7 @@ dependencies = [
 
 [[package]]
 name = "tracing_android_trace"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "android_trace",
  "smallvec",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,8 +11,12 @@ rust-version = "1.77"
 repository = "https://github.com/linebender/android_trace"
 edition = "2021"
 
-[workspace.dependencies]
-android_trace = { path = "./android_trace", version = "0.1.0", default-features = false }
+# Android Trace version, also used by other packages which want to mimic Android Trace's version.
+# Right now those packages include android_trace and tracing_android_trace.
+#
+# NOTE: When bumping this, remember to also bump the aforementioned other packages'
+#       version in the dependencies section at the bottom of this file.
+version = "0.1.1"
 
 [workspace.lints]
 rust.unreachable_pub = "warn"
@@ -22,3 +26,6 @@ rust.missing_docs = "warn"
 
 clippy.doc_markdown = "warn"
 clippy.semicolon_if_nothing_returned = "warn"
+
+[workspace.dependencies]
+android_trace = { path = "./android_trace", version = "0.1.1", default-features = false }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,12 +14,11 @@ edition = "2021"
 [workspace.dependencies]
 android_trace = { path = "./android_trace", version = "0.1.0", default-features = false }
 
-[workspace.lints.rust]
-unreachable_pub = "warn"
-unsafe_op_in_unsafe_fn = "warn"
-missing_debug_implementations = "warn"
-missing_docs = "warn"
+[workspace.lints]
+rust.unreachable_pub = "warn"
+rust.unsafe_op_in_unsafe_fn = "warn"
+rust.missing_debug_implementations = "warn"
+rust.missing_docs = "warn"
 
-[workspace.lints.clippy]
-doc_markdown = "warn"
-semicolon_if_nothing_returned = "warn"
+clippy.doc_markdown = "warn"
+clippy.semicolon_if_nothing_returned = "warn"

--- a/README.md
+++ b/README.md
@@ -25,6 +25,8 @@ Tracing spans for [Vello](https://github.com/linebender/vello) shown in Android 
 </figcaption>
 </figure>
 
+Significant changes are documented in [the changelog].
+
 ## Tracing Android Trace [tracing_android_trace](./tracing_android_trace)
 
 Tracing Android Trace provides several [`tracing_subscriber::Layer`][]s for Android NDK Tracing, using `ATrace_beginSection` and `ATrace_endSection`.
@@ -72,3 +74,4 @@ dual licensed as above, without any additional terms or conditions.
 [rust code of conduct]: https://www.rust-lang.org/policies/code-of-conduct
 [NDK Tracing]: https://developer.android.com/ndk/reference/group/tracing
 [`tracing_subscriber::Layer`]: https://docs.rs/tracing-subscriber/latest/tracing_subscriber/layer/trait.Layer.html
+[the changelog]: CHANGELOG.md

--- a/android_trace/Cargo.toml
+++ b/android_trace/Cargo.toml
@@ -4,9 +4,8 @@ description = "Support for Android NDK Tracing"
 categories = ["api-bindings", "os"]
 keywords = ["android", "logging", "atrace", "ndk"]
 readme = true
-# When updating, also update the version in the dependency in the workspace Cargo.toml
-version = "0.1.0"
 
+version.workspace = true
 license.workspace = true
 rust-version.workspace = true
 repository.workspace = true

--- a/android_trace/README.md
+++ b/android_trace/README.md
@@ -29,6 +29,8 @@ a sibling to this file's parent folder-->
 See [tracing_android_trace](https://crates.io/crates/tracing_android_trace)
 for an integration of this with [`tracing`](https://docs.rs/tracing/latest/tracing/).
 
+Significant changes are documented in [the changelog][].
+
 ## Quickstart
 
 Add a dependency on Android Trace:
@@ -120,6 +122,7 @@ Licensed under either of
 at your option.
 </div>
 
+[the changelog]: https://github.com/linebender/android_trace/blob/main/CHANGELOG.md
 [rust code of conduct]: https://www.rust-lang.org/policies/code-of-conduct
 [LICENSE-APACHE]: LICENSE-APACHE
 [LICENSE-MIT]: LICENSE-MIT

--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,0 +1,3 @@
+use_field_init_shorthand = true
+newline_style = "Unix"
+# TODO: imports_granularity = "Module" - Wait for this to be stable.

--- a/tracing_android_trace/Cargo.toml
+++ b/tracing_android_trace/Cargo.toml
@@ -8,8 +8,8 @@ categories = [
 ]
 keywords = ["android", "logging", "tracing"]
 readme = true
-version = "0.1.0"
 
+version.workspace = true
 license.workspace = true
 rust-version.workspace = true
 repository.workspace = true
@@ -17,7 +17,6 @@ edition.workspace = true
 
 [lints]
 workspace = true
-
 
 [dependencies]
 tracing-subscriber = { version = "0.3.18", default-features = false, features = [

--- a/tracing_android_trace/README.md
+++ b/tracing_android_trace/README.md
@@ -35,6 +35,8 @@ Tracing spans for [Vello](https://github.com/linebender/vello) shown in Android 
 </figcaption>
 </figure>
 
+Significant changes are documented in [the changelog][].
+
 ## Quickstart
 
 Add a dependency on Android Trace (and on [`tracing_subscriber`][]).
@@ -152,6 +154,7 @@ at your option.
 
 [NDK Tracing]: https://developer.android.com/ndk/reference/group/tracing
 [`android_trace`]: https://crates.io/crates/android_trace
+[the changelog]: https://github.com/linebender/android_trace/blob/main/CHANGELOG.md
 [rust code of conduct]: https://www.rust-lang.org/policies/code-of-conduct
 [LICENSE-APACHE]: LICENSE-APACHE
 [LICENSE-MIT]: LICENSE-MIT


### PR DESCRIPTION
- Add a CHANGELOG
- Tidy up some Cargo.toml features
- Increase the stable version in CI  (but not the MSRV)
- Bump version numbers in Cargo.toml
- Synchronise version numbers in Cargo.toml; this is a simplifying decision which has been true so far, and we can change it later if needed