### PR TITLE
Remove unused `Debug` bounds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,8 @@ You can find its changes [documented below](#011---2024-06-14).
 
 ### Fixed
 
+- Remove never used Debug bounds ([#17][] by [@DJMcNab])
+
 ## [0.1.1] - 2024-06-14
 
 ### Added
@@ -41,6 +43,7 @@ You can find its changes [documented below](#011---2024-06-14).
 [#11]: https://github.com/linebender/android_trace/pull/11
 [#12]: https://github.com/linebender/android_trace/pull/12
 [#13]: https://github.com/linebender/android_trace/pull/13
+[#17]: https://github.com/linebender/android_trace/pull/17
 
 [Unreleased]: https://github.com/linebender/android_trace/compare/v0.1.1...HEAD
 [0.1.1]: https://github.com/linebender/android_trace/compare/v0.1.0...v0.1.1

--- a/tracing_android_trace/src/sync_layer.rs
+++ b/tracing_android_trace/src/sync_layer.rs
@@ -103,8 +103,7 @@ struct ATraceExtension {
 
 impl<S> tracing_subscriber::Layer<S> for AndroidTraceLayer
 where
-    S: tracing::Subscriber + for<'a> LookupSpan<'a> + Debug,
-    for<'a> <S as LookupSpan<'a>>::Data: Debug,
+    S: tracing::Subscriber + for<'a> LookupSpan<'a>,
 {
     fn on_new_span(
         &self,


### PR DESCRIPTION
This prevents `tracing_android_trace` being used with `tracing_tracy`, unless `tracing_tracy` is added last